### PR TITLE
Clone Hero Converter hopo option can be deselected

### DIFF
--- a/Nautilus/PhaseShiftConverter.Designer.cs
+++ b/Nautilus/PhaseShiftConverter.Designer.cs
@@ -248,6 +248,7 @@
             // 
             this.dontAddHopoThreshold.BackColor = System.Drawing.SystemColors.GradientInactiveCaption;
             this.dontAddHopoThreshold.Checked = true;
+            this.dontAddHopoThreshold.CheckOnClick = true;
             this.dontAddHopoThreshold.CheckState = System.Windows.Forms.CheckState.Checked;
             this.dontAddHopoThreshold.Name = "dontAddHopoThreshold";
             this.dontAddHopoThreshold.Size = new System.Drawing.Size(406, 22);


### PR DESCRIPTION
Addresses issue #23: Cannot deselect "Don't add hopo threshold to .ini file"
Tested and the option seems to work as expected.