### PR TITLE
Setlist manager no vocals filter

### DIFF
--- a/Nautilus/SetlistManager.Designer.cs
+++ b/Nautilus/SetlistManager.Designer.cs
@@ -155,6 +155,7 @@
             this.chkRB2 = new System.Windows.Forms.CheckBox();
             this.chkRB1 = new System.Windows.Forms.CheckBox();
             this.PanelGender = new System.Windows.Forms.Panel();
+            this.chkNoVocals = new System.Windows.Forms.CheckBox();
             this.label3 = new System.Windows.Forms.Label();
             this.chkFemale = new System.Windows.Forms.CheckBox();
             this.chkMale = new System.Windows.Forms.CheckBox();
@@ -2179,6 +2180,7 @@
             this.PanelGender.BackColor = System.Drawing.Color.Transparent;
             this.PanelGender.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.PanelGender.ContextMenuStrip = this.contextMenuStrip1;
+            this.PanelGender.Controls.Add(this.chkNoVocals);
             this.PanelGender.Controls.Add(this.label3);
             this.PanelGender.Controls.Add(this.chkFemale);
             this.PanelGender.Controls.Add(this.chkMale);
@@ -2191,6 +2193,22 @@
             this.PanelGender.MouseDown += new System.Windows.Forms.MouseEventHandler(this.PanelsMouseDown);
             this.PanelGender.MouseMove += new System.Windows.Forms.MouseEventHandler(this.PanelsMouseMove);
             this.PanelGender.MouseUp += new System.Windows.Forms.MouseEventHandler(this.PanelsMouseUp);
+            // 
+            // chkNoVocals
+            // 
+            this.chkNoVocals.AutoSize = true;
+            this.chkNoVocals.BackColor = System.Drawing.Color.Transparent;
+            this.chkNoVocals.Checked = true;
+            this.chkNoVocals.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkNoVocals.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.chkNoVocals.Location = new System.Drawing.Point(72, 23);
+            this.chkNoVocals.Name = "chkNoVocals";
+            this.chkNoVocals.Size = new System.Drawing.Size(46, 17);
+            this.chkNoVocals.TabIndex = 7;
+            this.chkNoVocals.Text = "N/A";
+            this.toolTip1.SetToolTip(this.chkNoVocals, "Feminine lead singer");
+            this.chkNoVocals.UseVisualStyleBackColor = false;
+            this.chkNoVocals.CheckedChanged += new System.EventHandler(this.FiltersChanged);
             // 
             // label3
             // 
@@ -2210,11 +2228,11 @@
             this.chkFemale.Checked = true;
             this.chkFemale.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkFemale.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.chkFemale.Location = new System.Drawing.Point(67, 23);
+            this.chkFemale.Location = new System.Drawing.Point(42, 23);
             this.chkFemale.Name = "chkFemale";
-            this.chkFemale.Size = new System.Drawing.Size(49, 17);
+            this.chkFemale.Size = new System.Drawing.Size(32, 17);
             this.chkFemale.TabIndex = 3;
-            this.chkFemale.Text = "Fem.";
+            this.chkFemale.Text = "F";
             this.toolTip1.SetToolTip(this.chkFemale, "Feminine lead singer");
             this.chkFemale.UseVisualStyleBackColor = false;
             this.chkFemale.CheckedChanged += new System.EventHandler(this.FiltersChanged);
@@ -2226,11 +2244,11 @@
             this.chkMale.Checked = true;
             this.chkMale.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkMale.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.chkMale.Location = new System.Drawing.Point(10, 23);
+            this.chkMale.Location = new System.Drawing.Point(8, 23);
             this.chkMale.Name = "chkMale";
-            this.chkMale.Size = new System.Drawing.Size(55, 17);
+            this.chkMale.Size = new System.Drawing.Size(35, 17);
             this.chkMale.TabIndex = 2;
-            this.chkMale.Text = "Masc.";
+            this.chkMale.Text = "M";
             this.toolTip1.SetToolTip(this.chkMale, "Masculine lead singer");
             this.chkMale.UseVisualStyleBackColor = false;
             this.chkMale.CheckedChanged += new System.EventHandler(this.FiltersChanged);
@@ -4684,5 +4702,6 @@
         private System.Windows.Forms.PictureBox picLyrics;
         private System.Windows.Forms.CheckBox chkYear20;
         private System.Windows.Forms.ColumnHeader colListIndex;
+        private System.Windows.Forms.CheckBox chkNoVocals;
     }
 }

--- a/Nautilus/SetlistManager.cs
+++ b/Nautilus/SetlistManager.cs
@@ -95,6 +95,7 @@ namespace Nautilus
             Tools = new NemoTools();
             Parser  = new DTAParser();
             Songs = new List<SongData>();
+            AllSongs = new List<SongData>();
             duplicates = new List<int>();
             binFolder = Application.StartupPath + "\\bin\\";
             FormPanels = new List<Panel>
@@ -1963,6 +1964,10 @@ namespace Nautilus
             {
                 passes = false;
             }
+            else if (!chkNoVocals.Checked && song.GetGender() == "N/A")
+            {
+                passes = false;
+            }
             else if (cboGenre.SelectedIndex > 0 && song.Genre != cboGenre.SelectedItem.ToString())
             {
                 passes = false;
@@ -2857,6 +2862,7 @@ namespace Nautilus
             cboGenre.SelectedIndex = 0;
             chkMale.Checked = true;
             chkFemale.Checked = true;
+            chkNoVocals.Checked = true;
             txtSearch.Text = "";
             FilterInstruments(false);
             cboTime.SelectedIndex = 0;


### PR DESCRIPTION
We have this Lead Singer panel with Masc/Fem options, but this does not take into account songs with no vocals.

My use case is that I wanted to export a PDF with just Fem singers because I find some people prefer to sing those but they only make up about 10% of my library.  However, with the options currently available the instrumental songs were always getting included in the list.

To not disrupt the layout I changed the options to display as M, F, and N/A

![instrumental](https://github.com/user-attachments/assets/a29139c3-56ee-4ae5-8d35-689bb5f89608)

(also I initialized AllSongs on form load due to a runtime error I was getting)