### PR TITLE
Fix parsed drum_bank value with quotes

### DIFF
--- a/Nautilus/DTAParser.cs
+++ b/Nautilus/DTAParser.cs
@@ -959,7 +959,7 @@ namespace Nautilus
                             }
                             else if (line.Contains("drum_bank"))
                             {
-                                song.DrumBank = line.Replace("drum_bank", "").Replace("(", "").Replace(")", "").Trim();
+                                song.DrumBank = getDTAStringValue(line, "drum_bank");
                             }
                             else if (line.Contains("song_scroll_speed"))
                             {
@@ -2237,6 +2237,17 @@ namespace Nautilus
             {
                 return 0;
             }
+        }
+
+        /// <summary>
+        /// Can be used to get the raw string value of a single dta line containing a specific field
+        /// <code>getDTAStringValue("('some field' 'some value')", "some field") => "some value"</code>
+        /// </summary>
+        private string getDTAStringValue(string line, string field)
+        {
+            string quote = "['\"]";
+            string stripOut = "['\"()]|;.*?$"; // quotes, parens, comments
+            return Regex.Replace(Regex.Replace(line, $"{quote}?{field}{quote}?", ""), stripOut, "").Trim();
         }
 
         /// <summary>

--- a/Nautilus/DTAParser.cs
+++ b/Nautilus/DTAParser.cs
@@ -2240,14 +2240,21 @@ namespace Nautilus
         }
 
         /// <summary>
-        /// Can be used to get the raw string value of a single dta line containing a specific field
-        /// <code>getDTAStringValue("('some field' 'some value')", "some field") => "some value"</code>
+        /// Can be used to get the raw string value of a DTA entry containing a specified field.
+        /// <code>getDTAStringValue("('name' 'Ain't Messin Round (RB3 version)')", "name") => Ain't Messin Round (RB3 version)</code>
+        /// <code>getDTAStringValue("\t(\n\tdrum_bank\n\t"sfx/kit01_bank.milo"\n)", "drum_bank") => sfx/kit01_bank.milo</code>
         /// </summary>
         private string getDTAStringValue(string line, string field)
         {
             string quote = "['\"]";
-            string stripOut = "['\"()]|;.*?$"; // quotes, parens, comments
-            return Regex.Replace(Regex.Replace(line, $"{quote}?{field}{quote}?", ""), stripOut, "").Trim();
+            string openCloseParen = "^\\(|\\)$";
+            string openCloseQuote = $"^{quote}|{quote}$";
+
+            string result = RemoveDTAComments(line).Trim();
+            result = Regex.Replace(result, $"{quote}?{field}{quote}?", "").Trim();
+            result = Regex.Replace(result, openCloseParen, "").Trim();
+            result = Regex.Replace(result, openCloseQuote, "").Trim();
+            return result;
         }
 
         /// <summary>

--- a/Nautilus/DTAParser.cs
+++ b/Nautilus/DTAParser.cs
@@ -2241,7 +2241,7 @@ namespace Nautilus
 
         /// <summary>
         /// Can be used to get the raw string value of a DTA entry containing a specified field.
-        /// <code>getDTAStringValue("('name' "Ain't Messin Round (RB3 version)")", "name") => Ain't Messin Round (RB3 version)</code>
+        /// <code>getDTAStringValue("('name' \"Ain't Messin Round (RB3 version)\")", "name") => Ain't Messin Round (RB3 version)</code>
         /// <code>getDTAStringValue("\t(\n\tdrum_bank\n\t"sfx/kit01_bank.milo"\n)", "drum_bank") => sfx/kit01_bank.milo</code>
         /// </summary>
         private string getDTAStringValue(string line, string field)

--- a/Nautilus/DTAParser.cs
+++ b/Nautilus/DTAParser.cs
@@ -2241,7 +2241,7 @@ namespace Nautilus
 
         /// <summary>
         /// Can be used to get the raw string value of a DTA entry containing a specified field.
-        /// <code>getDTAStringValue("('name' 'Ain't Messin Round (RB3 version)')", "name") => Ain't Messin Round (RB3 version)</code>
+        /// <code>getDTAStringValue("('name' "Ain't Messin Round (RB3 version)")", "name") => Ain't Messin Round (RB3 version)</code>
         /// <code>getDTAStringValue("\t(\n\tdrum_bank\n\t"sfx/kit01_bank.milo"\n)", "drum_bank") => sfx/kit01_bank.milo</code>
         /// </summary>
         private string getDTAStringValue(string line, string field)


### PR DESCRIPTION
Addresses issue #21  

drum_bank field had no handling of quotes for keys/values
Added a function that can isolate a string value for a given a dta entry

Would be cool to eventually make a general purpose Lisp object parser so that there's not so much string micro-management