### PR TITLE
feat: Added 'album mode' to Volume Normalizer

### DIFF
--- a/Nautilus/DTAParser.cs
+++ b/Nautilus/DTAParser.cs
@@ -1226,6 +1226,10 @@ namespace Nautilus
                             {
                                 song.VNAudioHash = line.Replace(";VolumeNormalizerAudioHash=", "").Trim();
                             }
+                            else if (line.Contains(";NormalizedAsAlbum="))
+                            {
+                                song.NormalizedAsAlbum = (line.Replace(";NormalizedAsAlbum=", "").Trim() == "0") ? false : true;
+                            }
                         }
                         catch (Exception ex)
                         {
@@ -2823,6 +2827,7 @@ namespace Nautilus
         public bool HasSongIDError { get; set; }
         public string VNAudioHash { get; set; }
         public double BPM { get; set; }
+        public bool NormalizedAsAlbum { get; set; }
 
         public DateTime DateAdded { get; set; }
 
@@ -2920,6 +2925,7 @@ namespace Nautilus
             ChannelsVocalsStart = 0;
             ChannelsCrowdStart = 0;
             DateAdded = DateTime.Now;
+            NormalizedAsAlbum = false;
         }
 
         public string GetRating()

--- a/Nautilus/VolumeNormalizer.Designer.cs
+++ b/Nautilus/VolumeNormalizer.Designer.cs
@@ -35,6 +35,7 @@
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.btnBegin = new System.Windows.Forms.Button();
             this.picPin = new System.Windows.Forms.PictureBox();
+            this.chkAlbumMode = new System.Windows.Forms.CheckBox();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.chkRestore = new System.Windows.Forms.ToolStripMenuItem();
@@ -59,6 +60,7 @@
             this.lblTargetVolume = new System.Windows.Forms.Label();
             this.radioDoNotRender = new System.Windows.Forms.RadioButton();
             this.radioAllowRender = new System.Windows.Forms.RadioButton();
+            this.lblResetVolEnabled = new System.Windows.Forms.Label();
             this.contextMenuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.picPin)).BeginInit();
             this.menuStrip1.SuspendLayout();
@@ -137,6 +139,19 @@
             this.toolTip1.SetToolTip(this.picPin, "Click to pin on top");
             this.picPin.MouseClick += new System.Windows.Forms.MouseEventHandler(this.picPin_MouseClick);
             // 
+            // chkAlbumMode
+            // 
+            this.chkAlbumMode.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.chkAlbumMode.AutoSize = true;
+            this.chkAlbumMode.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.chkAlbumMode.Location = new System.Drawing.Point(213, 34);
+            this.chkAlbumMode.Name = "chkAlbumMode";
+            this.chkAlbumMode.Size = new System.Drawing.Size(394, 29);
+            this.chkAlbumMode.TabIndex = 73;
+            this.chkAlbumMode.Text = "Adjust all CONs equally (album mode)";
+            this.chkAlbumMode.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.chkAlbumMode.UseVisualStyleBackColor = true;
+            // 
             // menuStrip1
             // 
             this.menuStrip1.BackColor = System.Drawing.SystemColors.GradientInactiveCaption;
@@ -169,6 +184,7 @@
             this.chkRestore.Name = "chkRestore";
             this.chkRestore.Size = new System.Drawing.Size(234, 22);
             this.chkRestore.Text = "Restore Original Volumes";
+            this.chkRestore.Click += new System.EventHandler(this.chkRestore_Click);
             // 
             // toolStripSeparator1
             // 
@@ -414,12 +430,26 @@
             this.radioAllowRender.Text = "Allow re-rendering audio";
             this.radioAllowRender.UseVisualStyleBackColor = true;
             // 
+            // lblResetVolEnabled
+            // 
+            this.lblResetVolEnabled.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.lblResetVolEnabled.AutoSize = true;
+            this.lblResetVolEnabled.ForeColor = System.Drawing.Color.Red;
+            this.lblResetVolEnabled.Location = new System.Drawing.Point(213, 175);
+            this.lblResetVolEnabled.Name = "lblResetVolEnabled";
+            this.lblResetVolEnabled.Size = new System.Drawing.Size(339, 25);
+            this.lblResetVolEnabled.TabIndex = 74;
+            this.lblResetVolEnabled.Text = "Restore Original Volumes enabled";
+            this.lblResetVolEnabled.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.lblResetVolEnabled.Visible = false;
+            // 
             // VolumeNormalizer
             // 
             this.AllowDrop = true;
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             this.BackColor = System.Drawing.SystemColors.GradientInactiveCaption;
             this.ClientSize = new System.Drawing.Size(592, 356);
+            this.Controls.Add(this.chkAlbumMode);
             this.Controls.Add(this.grpMogg);
             this.Controls.Add(this.picPin);
             this.Controls.Add(this.picWorking);
@@ -430,8 +460,10 @@
             this.Controls.Add(this.btnBegin);
             this.Controls.Add(this.menuStrip1);
             this.Controls.Add(this.lstLog);
+            this.Controls.Add(this.lblResetVolEnabled);
             this.DoubleBuffered = true;
             this.MaximizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(608, 395);
             this.Name = "VolumeNormalizer";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Volume Normalizer";
@@ -485,5 +517,7 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
         private System.Windows.Forms.ToolStripMenuItem chkVerboseOutput;
         public System.Windows.Forms.ListBox lstLog;
+        private System.Windows.Forms.CheckBox chkAlbumMode;
+        private System.Windows.Forms.Label lblResetVolEnabled;
     }
 }

--- a/bin/help/vn
+++ b/bin/help/vn
@@ -6,3 +6,5 @@ This operation will modify the volume levels of the song, as well as write the o
 
 OPTIONS
 'Restore Original Volumes' will read the original volume levels in the DTA, and restore them to their original state. This operation will also write the original volumes to the DTA if the DTA has not been modified.
+'Analyzer Mode' will simply report the volume of each song, without modifying the DTA to update these volumes. It effectively acts as a 'read-only' mode. Note that 'Restore Original Volumes' will take precedence over this option.
+'Adjust all CONs equally (album mode)' will calculate an average volume change to apply to all songs in the folder, and then apply that singular value to all songs. This allows albums to maintain dynamic range within themselves, while still being generally brought into line with the rest of your library. Note that this cannot be applied when the option 'Restore Original Volumes' is selected. If 'Analyzer Mode' is selected, this will have no effect beyond calculating and displaying an average volume offset.

--- a/nautilus_changelog.txt
+++ b/nautilus_changelog.txt
@@ -6,6 +6,11 @@ Developed by TrojanNemo
 
 FEATURES / CHANGE LOG:
 
+vNightly (in source code, NOT in current release!)
+
+VOLUME NORMALIZER
+- A new option has been added to work in an "album mode". When this is enabled, all songs in a folder will be analysed first, and an average offset calculated. Then, this average offset will be applied to all the songs in the folder. If you have multiple songs from an album, and want to preserve the dynamics across the album, but still normalise the album against the rest of your library, this will allow you to do so.
+
 v5.6.0
 
 ROCK BAND TO KARAOKE CONVERTER


### PR DESCRIPTION
This is a functionality addition which allows the Volume Normalizer to operate on multiple files by taking all files within a folder, analysing them, calculating the average volume offset, and then applying that offset to each file in turn. In this way, albums with a large dynamic range can be normalised into a user's library, but without losing the relative dynamic range across the album; quiet songs are still relatively quiet, and vice versa.