### PR TITLE
Generate ID using shortname

### DIFF
--- a/Nautilus/BatchProcessor.cs
+++ b/Nautilus/BatchProcessor.cs
@@ -336,7 +336,7 @@ namespace Nautilus
                                                         var origID = Parser.GetSongID(line);
                                                         sw.WriteLine(";ORIG_ID=" + origID);
                                                         var corrector = new SongIDCorrector();
-                                                        line = "   ('song_id' " + corrector.ShortnameToSongID(Parser.Songs[0].InternalName) + ")";
+                                                        line = "   ('song_id' " + corrector.ShortnameToSongID(Parser.Songs[0].ShortName) + ")";
                                                         sw.WriteLine(line);
                                                         line = sr.ReadLine();
                                                     }

--- a/Nautilus/FileIndexer.Designer.cs
+++ b/Nautilus/FileIndexer.Designer.cs
@@ -632,8 +632,8 @@
             this.Controls.Add(this.lstFolders);
             this.Controls.Add(this.menuStrip1);
             this.DoubleBuffered = true;
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MainMenuStrip = this.menuStrip1;
+            this.MinimumSize = new System.Drawing.Size(632, 520);
             this.Name = "FileIndexer";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/Nautilus/PS3Converter.cs
+++ b/Nautilus/PS3Converter.cs
@@ -492,7 +492,7 @@ namespace Nautilus
                                             line = ";ORIG_ID=" + origID;
                                             sw.WriteLine(line);
                                             var corrector = new SongIDCorrector();
-                                            line = "   ('song_id' " + corrector.ShortnameToSongID(Parser.Songs[0].InternalName) + ")";
+                                            line = "   ('song_id' " + corrector.ShortnameToSongID(Parser.Songs[0].ShortName) + ")";
                                         }
                                     }
                                     if (line.Trim() != "")
@@ -1136,7 +1136,7 @@ namespace Nautilus
                             newline = ";ORIG_ID=" + origID;
                             sw.WriteLine(newline);
                             var corrector = new SongIDCorrector();
-                            var newID = corrector.ShortnameToSongID(Parser.Songs[0].InternalName);
+                            var newID = corrector.ShortnameToSongID(Parser.Songs[0].ShortName);
                             newline = "   ('song_id' " + newID + ")";
                             Log($"Song has an incorrect ID: {origID} - replacing with a correct ID: {newID}");
                             counter++;                            


### PR DESCRIPTION
Summary

- File index can now be resized without needing to maximize at Carl's request
- Batch Processor and PS3 Convert used the internal name, which generated correct IDs, but only in a few cases were these errors occurring, such as when the shortname contained mixed uppercase and lowercase letters and the files not, as seen in the image
<img width="788" height="622" alt="imagen" src="https://github.com/user-attachments/assets/8b9e8500-f146-435e-8e33-63d5ff5a0b76" />

So now it's linked to the shortname as it always was.